### PR TITLE
Rename context and merchant with backwards compat

### DIFF
--- a/lib/sneakers/value_objects.rb
+++ b/lib/sneakers/value_objects.rb
@@ -70,18 +70,26 @@ module Sneakers
       class ManifestItem
         include VirtusSerializable
 
-        attribute :context, String
-        attribute :merchant, String
+        attribute :financial_context_id, String
+        attribute :merchant_id, String
         attribute :product, String
         attribute :quantity, Integer
         attribute :amount_gross, Money
         attribute :amount_discount, Money
         attribute :extra, Hash
 
+        alias :merchant :merchant_id
+        alias :merchant= :merchant_id=
+        alias :context :financial_context_id
+        alias :context= :financial_context_id=
+
+        public :context=
+        public :merchant=
+
         def serialize
           super.values_at(*%w(
-            context
-            merchant
+            financial_context_id
+            merchant_id
             product
             quantity
             amount_gross

--- a/spec/donation_builder_spec.rb
+++ b/spec/donation_builder_spec.rb
@@ -80,7 +80,7 @@ module Sneakers
     end
 
     let(:order) do
-      Sneakers::DonationBuilder.supporter('au') .order(
+      Sneakers::DonationBuilder.supporter('au').order(
         supporter_donation,
         order_id,
         context,


### PR DESCRIPTION
[RELEASE] Renamed context to financial context id, merchant to merchant_id, and kept previous values for backwards compatibility
