### PR TITLE
Add OrderFee value object

### DIFF
--- a/lib/sneakers/value_objects.rb
+++ b/lib/sneakers/value_objects.rb
@@ -115,6 +115,25 @@ module Sneakers
         attribute :payer, Person
         attribute :manifest, Manifest
       end
+
+      class OrderFee
+        include VirtusSerializable
+
+        attribute :name, String
+        attribute :amount, Money
+      end
+
+      class OrderFeesCollection
+        include VirtusSerializable
+
+        attribute :components, Array[OrderFee]
+      end
+
+      class OrderFees
+        include VirtusSerializable
+
+        attribute :fees, OrderFeesCollection
+      end
     end
   end
 end

--- a/spec/value_objects_spec.rb
+++ b/spec/value_objects_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe Sneakers::ValueObjects::Payments::OrderFees do
+  let(:fees) do
+    {
+      fees: {
+        components: [
+          {
+            name: "p2p_donation",
+            amount: {
+              amount: "39.5",
+              currency: "AUD",
+            }
+          }
+        ]
+      }
+    }.deep_stringify_keys
+  end
+
+  it "parses fees" do
+    order_fees = described_class.new(fees)
+    expect(order_fees.serialize).to eq(fees)
+  end
+end


### PR DESCRIPTION
Because parsing json is boring. This should help with reading webhooks from payments. 
