### PR TITLE
Expose payload from VerifiedPayload

### DIFF
--- a/lib/sneakers/railtie.rb
+++ b/lib/sneakers/railtie.rb
@@ -17,11 +17,7 @@ module Sneakers
           end
 
           def verified_payload
-            Sneakers::VerifiedPayload.new(payload)
-          end
-
-          def payload
-            JSON.parse(request.body.read)
+            Sneakers::VerifiedPayload.new(JSON.parse(request.body.read))
           end
         end
       end

--- a/lib/sneakers/verified_payload.rb
+++ b/lib/sneakers/verified_payload.rb
@@ -3,12 +3,14 @@ require "sneakers/security_utils"
 
 module Sneakers
   class VerifiedPayload
-    def initialize(hash)
-      @hash = hash.deep_stringify_keys
+    def initialize(payload)
+      @payload = payload.deep_stringify_keys
     end
 
+    attr_reader :payload
+
     def sign(public_key)
-      Signature.sign(public_key, secret_key_for(public_key), @hash)
+      Signature.sign(public_key, secret_key_for(public_key), @payload)
     end
 
     def authentic?(signature)

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/verified_payload_spec.rb
+++ b/spec/verified_payload_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 module Sneakers
   RSpec.describe VerifiedPayload do
-    let(:hash) { {foo: "bar", baz: "bala"} }
-    let(:verified_payload) { described_class.new(hash) }
+    let(:payload) { {foo: "bar", baz: "bala"} }
+    let(:verified_payload) { described_class.new(payload) }
     let(:public_key) { "foo" }
     let(:secret_key) { "very-secret-key" }
     let(:signature) { "foo:v5mJKW74uUkBdXJ54TiQrvGk0fc=" }
@@ -27,6 +27,12 @@ module Sneakers
         it "is not authentic" do
           expect(verified_payload.authentic?("foo:wrong")).to be_falsy
         end
+      end
+    end
+
+    describe "#payload" do
+      it "exposes payload" do
+        expect(verified_payload.payload).to eq(payload.deep_stringify_keys)
       end
     end
   end


### PR DESCRIPTION
It allows us to move from the obscure method payload in our controllers
and use `verified_payload.payload` instead.

[RELEASE] Expose payload from VerifiedPayload
